### PR TITLE
copie d'un template pour corriger #49

### DIFF
--- a/lib/views/general/_followup.html.erb
+++ b/lib/views/general/_followup.html.erb
@@ -1,0 +1,197 @@
+<div id="followup" class="followup">
+  <% if (incoming_message.nil? || !incoming_message.valid_to_reply_to?)
+    # TRANSLATORS: This phrase completes the following sentences:
+    # Request an internal review from...
+    # Send a public follow up message to...
+    # Send a public reply to...
+    # Don't want to address your message to... ?
+    name_for_followup =
+      _("the main FOI contact at {{public_body}}",
+        public_body: h(OutgoingMailer.name_for_followup(@info_request, nil))) %>
+  <% else %>
+    <% name_for_followup =
+         h(OutgoingMailer.name_for_followup(@info_request, incoming_message)) %>
+  <% end %>
+
+  <% if @info_request.allow_new_responses_from != 'nobody' %>
+    <% if @info_request.embargo %>
+      <%= render partial: 'alaveteli_pro/followups/embargoed_form_title',
+                 locals: { incoming_message: incoming_message,
+                           name_for_followup: name_for_followup } %>
+    <% else %>
+      <%= render partial: 'form_title',
+                 locals: { incoming_message: incoming_message,
+                           name_for_followup: name_for_followup } %>
+    <% end %>
+
+    <% if incoming_message &&
+          @info_request.who_can_followup_to(incoming_message).any? %>
+      <%= render partial: 'choose_recipient',
+                 locals: { incoming_message: incoming_message,
+                           name_for_followup: name_for_followup } %>
+    <% end %>
+
+  <% end %>
+
+  <% if @info_request.allow_new_responses_from == 'nobody' %>
+    <p>
+      <%= # TRANSLATORS: "Follow ups" in this context means further
+          # messages sent by the requester to the authority after
+          # the initial request
+          _('Follow ups and new responses to this request have been stopped ' \
+            'to prevent spam. Please <a href="{{url}}">contact us</a> if you ' \
+            'are {{user_link}} and need to send a follow up.',
+            user_link: user_link(@info_request.user),
+            url: help_contact_path) %>
+    </p>
+  <% else %>
+    <% if @internal_review %>
+      <p>
+        <%= _('If you are dissatisfied by the response you got from the ' \
+              'public authority, you have the right to complain ' \
+              '(<a href="{{url}}">details</a>).',
+              url: help_unhappy_path(
+                     anchor: 'internal_review',
+                     url_title: @info_request.url_title)) %>
+      </p>
+    <% end %>
+
+    <p>
+    <%= _('Please <strong>only</strong> write messages directly relating ' \
+          'to your request {{request_link}}. If you would like to ask for ' \
+          'information that was not in your original request, then <a ' \
+          'href="{{new_request_link}}">file a new request</a>.',
+          request_link: request_link(@info_request),
+          new_request_link: new_request_to_body_url(
+                              url_name: @info_request.public_body.url_name)) %>
+    </p>
+
+    <% status = @info_request.calculate_status %>
+    <% if status == 'waiting_response_overdue' %>
+      <p>
+        <% if @info_request.public_body.not_subject_to_law? %>
+          <%= _('The response to your request has been <strong>delayed' \
+                '</strong>. Although the authority has no legal obligation ' \
+                'to reply, they should normally have responded by ' \
+                '<strong>{{date}}</strong>',
+                date: simple_date(@info_request.date_response_required_by)) %>
+
+          (<%= link_to _('details'),
+                       help_requesting_path(anchor: 'authorities') %>).
+        <% else %>
+          <%= _('The response to your request has been <strong>delayed' \
+                '</strong>. You can say that, by law, the authority should ' \
+                'normally have responded <strong>promptly</strong> and by ' \
+                '<strong>{{date}}</strong>',
+                date: simple_date(@info_request.date_response_required_by)) %>
+
+          (<%= link_to _('details'),
+                       help_requesting_path(anchor: 'quickly_response') %>).
+       <% end %>
+      </p>
+    <% elsif status == 'waiting_response_very_overdue' %>
+      <p>
+        <% if @info_request.public_body.not_subject_to_law? %>
+          <%= _('The response to your request is <strong>long overdue' \
+                '</strong>. Although the authority has no legal obligation ' \
+                'to reply, they should have responded by now') %>
+
+          (<%= link_to _('details'),
+                       help_requesting_path(anchor: 'authorities') %>).
+        <% else %>
+          <%= _('The response to your request is <strong>long overdue' \
+                '</strong>. You can say that, by law, under all ' \
+                'circumstances, the authority should have responded by now') %>
+
+          (<%= link_to _('details'),
+                       help_requesting_path(anchor: 'quickly_response') %>).
+        <% end %>
+      </p>
+    <% end %>
+
+    <% form_url =
+         if incoming_message.nil?
+           preview_request_followups_url(request_id: @info_request.id)
+         else
+           preview_request_followups_url(
+             request_id: @info_request.id,
+             incoming_message_id: incoming_message.id)
+         end -%>
+    <%= form_for @outgoing_message,
+                 html: { id: 'followup_form' },
+                 url: form_url do |o| %>
+      <p>
+        <%= o.text_area :body, rows: 15, cols: 55 %>
+      </p>
+
+      <% if @internal_review %>
+        <%= hidden_field_tag 'outgoing_message[what_doing]',
+                             'internal_review' %>
+      <% else %>
+        <h3><%= _('What are you doing?') %></h3>
+
+        <% if !@outgoing_message.errors[:what_doing_dummy].nil? %>
+          <div class="fieldWithErrors">
+        <% else %>
+          <div>
+        <% end %>
+          <!--
+            <div>
+            <%= radio_button 'outgoing_message',
+                             'what_doing',
+                             'new_information',
+                             id: 'new_information' %>
+            <label for="new_information">
+              <%= _('I am asking for <strong>new information</strong>') %>
+            </label>
+            </div>
+          -->
+          <div>
+            <%= radio_button 'outgoing_message',
+                             'what_doing',
+                             'internal_review',
+                             id: 'internal_review' %>
+            <label for="internal_review">
+              <%= _('I am requesting an <strong>internal review</strong>') %>
+              <%= link_to _("what's that?"), '/aide/insatisfait' %>
+            </label>
+          </div>
+
+          <div>
+            <%= radio_button 'outgoing_message',
+                             'what_doing',
+                             'normal_sort',
+                             id: 'sort_normal' %>
+            <label for="sort_normal">
+              <%= _('<strong>Anything else</strong>, such as clarifying, ' \
+                    'prompting, thanking') %>
+            </label>
+          </div>
+        </div>
+      <% end %>
+
+      <% if @internal_review %>
+        <p>
+          <%= _('Edit and add <strong>more details</strong> to the message ' \
+                'above, explaining why you are dissatisfied with their ' \
+                'response.') %>
+        </p>
+      <% end %>
+
+      <p>
+        <%= hidden_field_tag 'submitted_followup', 1 %>
+        <% if @internal_review %>
+          <%= hidden_field_tag(:internal_review, 1 ) %>
+        <% end %>
+        <%= submit_tag _('Preview your message') %>
+      </p>
+    <% end %>
+
+    <p>
+      <% if not @is_owning_user %>
+        <%= _('(You will be asked to sign in as {{user_name}})',
+              user_name: user_link(@info_request.user)) %>
+      <% end %>
+    </p>
+  <% end %>
+</div>

--- a/lib/views/general/_frontpage_hero.html.erb
+++ b/lib/views/general/_frontpage_hero.html.erb
@@ -8,7 +8,7 @@
               "{{number_of_requests}} requests</a> to " \
               "<a href=\"{{authorities_url}}\">" \
               "{{number_of_authorities}} authorities</a>",
-            :requests_url => "https://madada.fr/demandes/toutes?#results",
+            :requests_url => request_list_all_path,
             :number_of_requests => number_with_delimiter(@number_of_requests),
             :authorities_url => list_public_bodies_default_path,
             :number_of_authorities => number_with_delimiter(@number_of_authorities)) %>

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -17,26 +17,26 @@
 <p>Si l'autorité a refusé la communication des documents demandés à plusieurs reprises, ou vous a communiqué une version incomplète des documents demandés, vous pouvez : </p>
 
 <ol>
-  <li>demander une <strong><a href="#internal_review">reconsidération interne</a></strong> de la réponse apportée. </li>
+  <li>Effectuer un <strong><a href="#internal_review">recours</a></strong>auprès de l'autorité concernée. </li>
   <li>Si cela n'aide pas vous pouvez <a href="#complaining">saisir la <strong>CADA</strong></a></li>
   <li><a href="https://madada.fr/selectionner_autorite" class="hover_a">faire une nouvelle requête</a> en demandant des informations plus spécifiques ou plus précises ou en l'adressant à une autorité différente</li>
   <li>ou utiliser <a href="#other_means">d'autres moyens</a> pour formuler votre demande</li>
 </ol>
 
-<h1 id="internal_review">1. Demander une reconsidération <a class="hover_a" href="#internal_review">#</a> </h1>
+<h1 id="internal_review">1. Effectuer un recours <a class="hover_a" href="#internal_review">#</a> </h1>
 
 <p>
   <% if @info_request %>
-    <%= link_to "Demander une reconsidération", new_request_followup_path(:request_id => @info_request.id) + "?internal_review=1#followup", :class => 'link_button_green request-internal-review-action' %> et écrire unmessage demandant à l'autorité de reconsidérer votre demande.
+    <%= link_to "Effectuer un recours", new_request_followup_path(:request_id => @info_request.id) + "?internal_review=1#followup", :class => 'link_button_green request-internal-review-action' %> et écrire un message demandant à l'autorité de reconsidérer sa réponse à votre demande.
   <% else %>
-  Au bas de la page de demande associée sur <%= site_name %> choisissez "demander une reconsidération". 
+  Au bas de la page de demande associée sur <%= site_name %> choisissez "demander un recours". 
   Ensuite écrivez un message demandant une reconsidération interne de la réponse négative qui vous a été adressée. 
   Vous souhaiterez éventuellement inclure un lien vers la page de la demande, afin d'indiquer clairement la référence 
   de la demande à laquelle vous faites référence.  
   <% end %>
 </p>
 
-<p>Les procédures de reconsidération interne doivent être rapides. 
+<p>Les procédures de recours interne doivent être rapides. 
 Si cela prend plus de 20 jours ouvrés, l'autorité devrait alors vous en informer. 
 Dans tous les cas cela ne doit pas prendre plus de 40 jours ouvrés.
 Vous pourrez alors obtenir l'information que vous aviez demandé initialement, ou le refus d'accès vous sera confirmé. 
@@ -45,7 +45,7 @@ Vous pourrez alors obtenir l'information que vous aviez demandé initialement, o
 <h1 id="complaining">2. Saisir la CADA <a class="hover_a" href="#complaining">#</a> </h1>
 
 <p>Si vous êtes toujours mécontent.e après que l'autorité publique ait ré-examiné votre requête,
-  vous pouvez décider de saisir la Commission d'accès aux documents administratifs. Pour ce faire consulter la page de la FAQ dédiée à <a href="https://www.cada.fr/particulier/quand-et-comment-saisir-la-cada">cette procédure</a>
+  vous pouvez décider de saisir la Commission d'accès aux documents administratifs. Pour ce faire consulter la page de la FAQ dédiée à <a href="https://dada.fr/aide/cada">cette procédure</a>
   sur le site de la CADA.
 </p>
 


### PR DESCRIPTION
j'ai trouvé une référence à l'url qui pose problème quand les demandes ont dépassé le délai d'un mois et qu'une page présente à l'utilisateur.rrice les options possibles :
- faire une reconsidération . <a>De quoi s'agit-il ?
J'ai copié le fichier dans le theme madada et changé l'url pour corriger #49 

Au passage j'ai modifié la traduction de la chaîne internal review de reconsidération à recours (demander un recours ou effectuer un recours) dans transiflex.